### PR TITLE
Store id in raw_data

### DIFF
--- a/src/lib/database-migrations/002-raw.sql
+++ b/src/lib/database-migrations/002-raw.sql
@@ -4,11 +4,13 @@ CREATE TABLE raw_data (
     id BIGSERIAL PRIMARY KEY,
     publisher_feed_id INTEGER NOT NULL,
     rpde_id TEXT NOT NULL,
+    data_id TEXT NOT NULL,
     data_deleted boolean NOT NULL,
     data_kind TEXT NOT NULL,
     data_modified TEXT NOT NULL,
     data JSONB NULL,
     updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default (now() at time zone 'utc'),
     CONSTRAINT raw_data_rpde_id UNIQUE (publisher_feed_id, rpde_id),
+    CONSTRAINT raw_data_data_id UNIQUE (data_id),
     CONSTRAINT raw_data_publisher_feed_id FOREIGN KEY (publisher_feed_id) REFERENCES publisher_feed(id)
 );

--- a/src/lib/database-migrations/002-raw.sql
+++ b/src/lib/database-migrations/002-raw.sql
@@ -3,12 +3,12 @@ ALTER TABLE publisher_feed ADD raw_next_url TEXT NULL;
 CREATE TABLE raw_data (
     id BIGSERIAL PRIMARY KEY,
     publisher_feed_id INTEGER NOT NULL,
-    data_id TEXT NOT NULL,
+    rpde_id TEXT NOT NULL,
     data_deleted boolean NOT NULL,
     data_kind TEXT NOT NULL,
     data_modified TEXT NOT NULL,
     data JSONB NULL,
     updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default (now() at time zone 'utc'),
-    CONSTRAINT raw_data_data_id UNIQUE (publisher_feed_id, data_id),
+    CONSTRAINT raw_data_rpde_id UNIQUE (publisher_feed_id, rpde_id),
     CONSTRAINT raw_data_publisher_feed_id FOREIGN KEY (publisher_feed_id) REFERENCES publisher_feed(id)
 );

--- a/src/lib/database-migrations/002-raw.sql
+++ b/src/lib/database-migrations/002-raw.sql
@@ -4,7 +4,7 @@ CREATE TABLE raw_data (
     id BIGSERIAL PRIMARY KEY,
     publisher_feed_id INTEGER NOT NULL,
     rpde_id TEXT NOT NULL,
-    data_id TEXT NOT NULL,
+    data_id TEXT NULL,
     data_deleted boolean NOT NULL,
     data_kind TEXT NOT NULL,
     data_modified TEXT NOT NULL,

--- a/src/lib/download-raw.js
+++ b/src/lib/download-raw.js
@@ -37,11 +37,14 @@ async function store_raw_callback(publisher_feed, data, nextURL) {
 
         for (const activityItem of data) {
 
+            const idFromData = Utils.getIdFromData(activityItem, publisher_feed.url);
+
             if (activityItem.state == 'updated' || activityItem.state == 'deleted'){
 
                 const query_data = [
                     publisher_feed.id,
                     activityItem.id,
+                    idFromData,
                     (activityItem.state == 'updated'?'f':'t'),
                     activityItem.kind,
                     activityItem.modified,
@@ -49,8 +52,8 @@ async function store_raw_callback(publisher_feed, data, nextURL) {
                 ];
 
                 await client.query(
-                    'INSERT INTO raw_data (publisher_feed_id, rpde_id, data_deleted, data_kind, data_modified, data, normalised) ' +
-                    'VALUES ($1, $2, $3, $4, $5, $6, \'f\') ' +
+                    'INSERT INTO raw_data (publisher_feed_id, rpde_id, data_id, data_deleted, data_kind, data_modified, data, normalised) ' +
+                    'VALUES ($1, $2, $3, $4, $5, $6, $7, \'f\') ' +
                     'ON CONFLICT (publisher_feed_id, rpde_id) DO UPDATE SET ' +
                     'data_deleted=$3, data_modified=$5, data=$6, updated_at=(now() at time zone \'utc\'), normalised=\'f\', validation_done=\'f\', validation_passed=\'f\', validation_results=NULL'  ,
                     query_data

--- a/src/lib/download-raw.js
+++ b/src/lib/download-raw.js
@@ -49,9 +49,9 @@ async function store_raw_callback(publisher_feed, data, nextURL) {
                 ];
 
                 await client.query(
-                    'INSERT INTO raw_data (publisher_feed_id, data_id, data_deleted, data_kind, data_modified, data, normalised) ' +
+                    'INSERT INTO raw_data (publisher_feed_id, rpde_id, data_deleted, data_kind, data_modified, data, normalised) ' +
                     'VALUES ($1, $2, $3, $4, $5, $6, \'f\') ' +
-                    'ON CONFLICT (publisher_feed_id, data_id) DO UPDATE SET ' +
+                    'ON CONFLICT (publisher_feed_id, rpde_id) DO UPDATE SET ' +
                     'data_deleted=$3, data_modified=$5, data=$6, updated_at=(now() at time zone \'utc\'), normalised=\'f\', validation_done=\'f\', validation_passed=\'f\', validation_results=NULL'  ,
                     query_data
                 );

--- a/src/lib/download-raw.js
+++ b/src/lib/download-raw.js
@@ -17,7 +17,6 @@ async function download_raw_all_publisher_feeds() {
         }
     } catch(error) {
         console.error("ERROR download_raw_all_publisher_feeds");
-        console.error(data);
         console.error(error);
 
     } finally {
@@ -37,7 +36,7 @@ async function store_raw_callback(publisher_feed, data, nextURL) {
 
         for (const activityItem of data) {
 
-            const idFromData = Utils.getIdFromData(activityItem, publisher_feed.url);
+            const idFromData = Utils.getIdFromData(activityItem.data, publisher_feed.url);
 
             if (activityItem.state == 'updated' || activityItem.state == 'deleted'){
 
@@ -55,7 +54,7 @@ async function store_raw_callback(publisher_feed, data, nextURL) {
                     'INSERT INTO raw_data (publisher_feed_id, rpde_id, data_id, data_deleted, data_kind, data_modified, data, normalised) ' +
                     'VALUES ($1, $2, $3, $4, $5, $6, $7, \'f\') ' +
                     'ON CONFLICT (publisher_feed_id, rpde_id) DO UPDATE SET ' +
-                    'data_deleted=$3, data_modified=$5, data=$6, updated_at=(now() at time zone \'utc\'), normalised=\'f\', validation_done=\'f\', validation_passed=\'f\', validation_results=NULL'  ,
+                    'data_id=$3, data_deleted=$4, data_modified=$6, data=$7, updated_at=(now() at time zone \'utc\'), normalised=\'f\', validation_done=\'f\', validation_passed=\'f\', validation_results=NULL'  ,
                     query_data
                 );
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -39,21 +39,18 @@ class Utils {
     return await Utils.readJson(path.resolve(path.resolve(), './src/lib/oa.jsonld'));
   }
 
-  static getIdFromData(data, feedUrl){
-    // Gets or generates a unique id from data.
-    // data is the contents of the `data` field on an object in an RPDE feed
-    // Returns `@id` if present; if not returns `id`.
-    // If neither returns feed_url + `identifier`
-
-    if(typeof data["@id"] !== 'undefined'){
-      return data["@id"];
-    }else if(typeof data.id !== 'undefined'){
-      return data.id;
-    }else if(typeof data.identifier !== 'undefined'){
-      if(feedUrl.slice(-1) != "/"){
-        feedUrl = feedUrl + "/";
+  static getIdFromData(data){
+    // Gets the id from a data object, only if it's a valid URI
+    if(typeof data !== 'undefined'){
+      let id;
+      if(typeof data["@id"] !== 'undefined'){
+        id = data["@id"];
+      }else if(typeof data.id !== 'undefined'){
+        id = data.id;
       }
-      return feedUrl + data.identifier;
+      if(typeof id === 'string' && id.includes('http')){
+        return id;
+      }
     }
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -39,7 +39,7 @@ class Utils {
     return await Utils.readJson(path.resolve(path.resolve(), './src/lib/oa.jsonld'));
   }
 
-  static getIdFromData(data, feed_url){
+  static getIdFromData(data, feedUrl){
     // Gets or generates a unique id from data.
     // data is the contents of the `data` field on an object in an RPDE feed
     // Returns `@id` if present; if not returns `id`.
@@ -50,10 +50,10 @@ class Utils {
     }else if(typeof data.id !== 'undefined'){
       return data.id;
     }else if(typeof data.identifier !== 'undefined'){
-      if(feed_url.slice(-1) != "/"){
-        feed_url = feed_url + "/";
+      if(feedUrl.slice(-1) != "/"){
+        feedUrl = feedUrl + "/";
       }
-      return feed_url + data.identifier;
+      return feedUrl + data.identifier;
     }
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -39,6 +39,24 @@ class Utils {
     return await Utils.readJson(path.resolve(path.resolve(), './src/lib/oa.jsonld'));
   }
 
+  static getIdFromData(data, feed_url){
+    // Gets or generates a unique id from data.
+    // data is the contents of the `data` field on an object in an RPDE feed
+    // Returns `@id` if present; if not returns `id`.
+    // If neither returns feed_url + `identifier`
+
+    if(typeof data["@id"] !== 'undefined'){
+      return data["@id"];
+    }else if(typeof data.id !== 'undefined'){
+      return data.id;
+    }else if(typeof data.identifier !== 'undefined'){
+      if(feed_url.slice(-1) != "/"){
+        feed_url = feed_url + "/";
+      }
+      return feed_url + data.identifier;
+    }
+  }
+
   static ensureArray(input){
     // if input is an array, returns it directly
     // otherwise puts input into an array and returns that

--- a/src/lib/web-rpde-query.js
+++ b/src/lib/web-rpde-query.js
@@ -28,11 +28,11 @@ class RPDEQuery {
     sql += " WHERE updated_at < ((now() at time zone 'utc') - interval '"+ this.dont_serve_data_until_seconds_old +" seconds') ";
     // Now if user has specified after, add those
     if (this.afterTimestamp && this.afterId) {
-       sql += " AND ( ( extract(epoch from updated_at)::int = $2 AND data_id > $3) OR (extract(epoch from updated_at)::int > $2)) ";
+       sql += " AND ( ( extract(epoch from updated_at)::int = $2 AND rpde_id > $3) OR (extract(epoch from updated_at)::int > $2)) ";
        params.push(this.afterTimestamp, this.afterId);
     }
     // Finally order and limit
-    sql += "ORDER BY extract(epoch from updated_at)::int ASC, data_id ASC LIMIT $1";
+    sql += "ORDER BY extract(epoch from updated_at)::int ASC, rpde_id ASC LIMIT $1";
     // ----- Run Query, store results
     const client = await database_pool.connect();
     try {
@@ -41,14 +41,14 @@ class RPDEQuery {
             const item = {
                 "state": (database_data.data_deleted ? "deleted" : "updated"),
                 "kind": database_data.data_kind,
-                "id": database_data.data_id,
+                "id": database_data.rpde_id,
                 "modified": database_data.updated_at,
             };
             if (!database_data.data_deleted) {
                 item.data = database_data.data;
             }
             this.rows.push(item);
-            this.next_afterId = database_data.data_id;
+            this.next_afterId = database_data.rpde_id;
             this.next_afterTimestamp = database_data.updated_at;
         }
     } catch(error) {

--- a/src/lib/web-rpde-query.js
+++ b/src/lib/web-rpde-query.js
@@ -28,11 +28,11 @@ class RPDEQuery {
     sql += " WHERE updated_at < ((now() at time zone 'utc') - interval '"+ this.dont_serve_data_until_seconds_old +" seconds') ";
     // Now if user has specified after, add those
     if (this.afterTimestamp && this.afterId) {
-       sql += " AND ( ( extract(epoch from updated_at)::int = $2 AND rpde_id > $3) OR (extract(epoch from updated_at)::int > $2)) ";
+       sql += " AND ( ( extract(epoch from updated_at)::int = $2 AND data_id > $3) OR (extract(epoch from updated_at)::int > $2)) ";
        params.push(this.afterTimestamp, this.afterId);
     }
     // Finally order and limit
-    sql += "ORDER BY extract(epoch from updated_at)::int ASC, rpde_id ASC LIMIT $1";
+    sql += "ORDER BY extract(epoch from updated_at)::int ASC, data_id ASC LIMIT $1";
     // ----- Run Query, store results
     const client = await database_pool.connect();
     try {
@@ -41,14 +41,14 @@ class RPDEQuery {
             const item = {
                 "state": (database_data.data_deleted ? "deleted" : "updated"),
                 "kind": database_data.data_kind,
-                "id": database_data.rpde_id,
+                "id": database_data.data_id,
                 "modified": database_data.updated_at,
             };
             if (!database_data.data_deleted) {
                 item.data = database_data.data;
             }
             this.rows.push(item);
-            this.next_afterId = database_data.rpde_id;
+            this.next_afterId = database_data.data_id;
             this.next_afterTimestamp = database_data.updated_at;
         }
     } catch(error) {

--- a/test/test-normalise-data.js
+++ b/test/test-normalise-data.js
@@ -25,7 +25,7 @@ describe('normalise data', function() {
             const res_select_publisher_feed = await client.query('SELECT * FROM publisher_feed');
             publisher_feed = res_select_publisher_feed.rows[0];
             // Raw data
-            const res_add_raw = await client.query('INSERT INTO raw_data (publisher_feed_id, rpde_id, data_deleted, data_kind, data_modified, data) VALUES ($1, $2, $3, $4, $5, $6)', [publisher_feed_id, "D1",false, "CATS", "1", {test:true}]);
+            const res_add_raw = await client.query('INSERT INTO raw_data (publisher_feed_id, rpde_id, data_id, data_deleted, data_kind, data_modified, data) VALUES ($1, $2, $3, $4, $5, $6, $7)', [publisher_feed_id, "D1","https://example.org/test/1",false, "CATS", "1", {test:true}]);
 
         } catch(error) {
             console.error("ERROR in test");

--- a/test/test-normalise-data.js
+++ b/test/test-normalise-data.js
@@ -25,7 +25,7 @@ describe('normalise data', function() {
             const res_select_publisher_feed = await client.query('SELECT * FROM publisher_feed');
             publisher_feed = res_select_publisher_feed.rows[0];
             // Raw data
-            const res_add_raw = await client.query('INSERT INTO raw_data (publisher_feed_id, data_id, data_deleted, data_kind, data_modified, data) VALUES ($1, $2, $3, $4, $5, $6)', [publisher_feed_id, "D1",false, "CATS", "1", {test:true}]);
+            const res_add_raw = await client.query('INSERT INTO raw_data (publisher_feed_id, rpde_id, data_deleted, data_kind, data_modified, data) VALUES ($1, $2, $3, $4, $5, $6)', [publisher_feed_id, "D1",false, "CATS", "1", {test:true}]);
 
         } catch(error) {
             console.error("ERROR in test");

--- a/test/test-normalise-deleted-data.js
+++ b/test/test-normalise-deleted-data.js
@@ -25,7 +25,7 @@ describe('normalise deleted raw data', function() {
             const res_select_publisher_feed = await client.query('SELECT * FROM publisher_feed');
             publisher_feed = res_select_publisher_feed.rows[0];
             // Raw data
-            const res_add_raw = await client.query('INSERT INTO raw_data (publisher_feed_id, data_id, data_deleted, data_kind, data_modified, data) VALUES ($1, $2, $3, $4, $5, $6)', [publisher_feed_id, "D1",true, "CATS", "1", null]);
+            const res_add_raw = await client.query('INSERT INTO raw_data (publisher_feed_id, rpde_id, data_deleted, data_kind, data_modified, data) VALUES ($1, $2, $3, $4, $5, $6)', [publisher_feed_id, "D1",true, "CATS", "1", null]);
 
         } catch(error) {
             console.error("ERROR in test");

--- a/test/test-normalise-deleted-data.js
+++ b/test/test-normalise-deleted-data.js
@@ -25,7 +25,7 @@ describe('normalise deleted raw data', function() {
             const res_select_publisher_feed = await client.query('SELECT * FROM publisher_feed');
             publisher_feed = res_select_publisher_feed.rows[0];
             // Raw data
-            const res_add_raw = await client.query('INSERT INTO raw_data (publisher_feed_id, rpde_id, data_deleted, data_kind, data_modified, data) VALUES ($1, $2, $3, $4, $5, $6)', [publisher_feed_id, "D1",true, "CATS", "1", null]);
+            const res_add_raw = await client.query('INSERT INTO raw_data (publisher_feed_id, rpde_id, data_id, data_deleted, data_kind, data_modified, data) VALUES ($1, $2, $3, $4, $5, $6, $7)', [publisher_feed_id, "D1", "https://example.org/events/1",true, "CATS", "1", null]);
 
         } catch(error) {
             console.error("ERROR in test");

--- a/test/test-pipe-test-pipe.js
+++ b/test/test-pipe-test-pipe.js
@@ -11,7 +11,7 @@ import TestPipe from '../src/lib/pipes/test-pipe.js';
 describe('test-pipe', function() {
     it('basic test', function(done) {
 
-        let pipe = new TestPipe({id: 67, data_id: "ABC", data: {"test":true }}, []);
+        let pipe = new TestPipe({id: 67, rpde_id: "ABC", data: {"test":true }}, []);
         let results_promise = pipe.run();
         results_promise.then((results)=> {
 

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -35,7 +35,7 @@ describe('getIdFromData', function(){
             "id": "https://example.org/events/2",
             "identifier": "event1"
         }
-        const id = Utils.getIdFromData(data, "https://example.org/events/");
+        const id = Utils.getIdFromData(data);
         assert.equal(id, "https://example.org/events/1");
     });
 
@@ -44,23 +44,25 @@ describe('getIdFromData', function(){
             "id": "https://example.org/events/2",
             "identifier": "event1"
         }
-        const id = Utils.getIdFromData(data, "https://example.org/events/");
+        const id = Utils.getIdFromData(data);
         assert.equal(id, "https://example.org/events/2");
     });
 
-    it('should return the identifier value', function(){
+    it('should return undefined if id is not a HTTP URI', function(){
         const data = {
-            "identifier": "event1"
+            "@id": "event1"
         }
-        const id = Utils.getIdFromData(data, "https://example.org/events/");
-        assert.equal(id, "https://example.org/events/event1");
+        const id = Utils.getIdFromData(data);
+        assert.deepEqual(id, undefined);
     });
 
-    it('should return the identifier value when feed has no /', function(){
-        const data = {
-            "identifier": "event1"
-        }
-        const id = Utils.getIdFromData(data, "https://example.org/events");
-        assert.equal(id, "https://example.org/events/event1");
+    it('should return undefined if @id/id is undefined', function(){
+        const id = Utils.getIdFromData({"blah": "nothing"});
+        assert.deepEqual(id, undefined);
+    });
+
+    it('should return undefined if data is undefined', function(){
+        const id = Utils.getIdFromData(undefined);
+        assert.deepEqual(id, undefined);
     });
 });

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -27,3 +27,40 @@ describe('getContext', function() {
 
     });
 });
+
+describe('getIdFromData', function(){
+    it('should return the @id value', function(){
+        const data = {
+            "@id": "https://example.org/events/1",
+            "id": "https://example.org/events/2",
+            "identifier": "event1"
+        }
+        const id = Utils.getIdFromData(data, "https://example.org/events/");
+        assert.equal(id, "https://example.org/events/1");
+    });
+
+    it('should return the id value', function(){
+        const data = {
+            "id": "https://example.org/events/2",
+            "identifier": "event1"
+        }
+        const id = Utils.getIdFromData(data, "https://example.org/events/");
+        assert.equal(id, "https://example.org/events/2");
+    });
+
+    it('should return the identifier value', function(){
+        const data = {
+            "identifier": "event1"
+        }
+        const id = Utils.getIdFromData(data, "https://example.org/events/");
+        assert.equal(id, "https://example.org/events/event1");
+    });
+
+    it('should return the identifier value when feed has no /', function(){
+        const data = {
+            "identifier": "event1"
+        }
+        const id = Utils.getIdFromData(data, "https://example.org/events");
+        assert.equal(id, "https://example.org/events/event1");
+    });
+});


### PR DESCRIPTION
Renames current data_id field in raw_data to rpde_id.
Uses data_id instead for the value of @id/id/feedUrl+identifier in the OA data object.

Heads up @michaelwood @Lathrisk @robredpath, this is a breaking change to the database schema that means you should completely delete your local copy and re-download raw data when merged.