### PR TITLE
Error handling in normalisatin pipes

### DIFF
--- a/test/test-pipe-normalise-event.js
+++ b/test/test-pipe-normalise-event.js
@@ -170,3 +170,37 @@ describe('course-instance', function(){
         assert.deepEqual(results[0].data, output.data);
     });
 });
+
+describe('test-errors', function(){
+    it('should set an error for a missing superEvent', async function(){
+        const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/scheduledsession-referenced-superevent-2.json'));
+        const error = {"missingSuperEvent": `No raw_data with data_id [https://ncc.leisurecloud.net/OpenActive/api/session-series/HRES0001802]`}
+
+        let pipe = new NormaliseEventPipe(input, []);
+        let results = await pipe.run();
+        assert.equal(results[0].errors.length, 1);
+        assert.deepEqual(results[0].errors[0], error);
+    });
+
+    it('should set an error for an invalid superEvent value', async function(){
+        const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/scheduledsession-referenced-superevent-2.json'));
+        input.data.superEvent = "notavaliduri";
+        const error = {"invalidSuperEvent": `Can't process superEvent value [notavaliduri]`}
+
+        let pipe = new NormaliseEventPipe(input, []);
+        let results = await pipe.run();
+        assert.equal(results[0].errors.length, 1);
+        assert.deepEqual(results[0].errors[0], error);
+    });
+
+    it('should set an error for an invalid superEvent type', async function(){
+        const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/scheduledsession-referenced-superevent-2.json'));
+        input.data.superEvent = ["https://example.org/superevent"];
+        const error = {"invalidSuperEvent": `Can't process superEvent value [https://example.org/superevent]`}
+
+        let pipe = new NormaliseEventPipe(input, []);
+        let results = await pipe.run();
+        assert.equal(results[0].errors.length, 1);
+        assert.deepEqual(results[0].errors[0], error);
+    });
+})

--- a/test/test-pipe-normalise-schedule.js
+++ b/test/test-pipe-normalise-schedule.js
@@ -43,6 +43,10 @@ describe('course-schedule', function() {
         assert.deepEqual(results[1].data, output[1].data);
     });
 
+});
+
+describe('session-schedule', function() {
+
     it('should generate two correct Normalised Events from a SessionSeries with eventSchedule', async function(){
         const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/sessionseries-with-schedule.json'));
         const output = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/sessionseries-with-schedule-normalised.json'));
@@ -80,6 +84,10 @@ describe('course-schedule', function() {
         assert.equal(results.length,1);
         assert.deepEqual(results[0].data, output[0].data);
     });
+
+});
+
+describe('error-handling', function() {
 
     it('should generate events when byDay value uses http', async function() {
 


### PR DESCRIPTION
When the normalisation process has errors but they don't prevent a NormalisedEvent from being generated, the errors are stored