### PR TITLE
GeoPipe

### DIFF
--- a/src/lib/pipes/geo-pipe.js
+++ b/src/lib/pipes/geo-pipe.js
@@ -1,0 +1,120 @@
+import Pipe from './pipe.js';
+import { cache, Utils } from '../utils.js';
+import fetch from 'node-fetch';
+import Settings from '../settings.js';
+
+/*
+The GeoPipe adds more location data given a postcode:
+  - coordinates in a `geo` object
+  - locality
+  - region
+  - country
+*/
+class GeoPipe extends Pipe {
+  run(){
+    return new Promise(async resolve => {
+
+      for(let idx in this.normalisedEvents) {
+
+        let postcode = this.getPostcode(this.normalisedEvents[idx].data.location);
+        if (postcode != undefined) {
+
+          let postcodeData;
+
+          if (!cache.postcodes[postcode]){
+            let lookupError = await this.lookupPostcode(postcode);
+
+            if(lookupError != undefined){
+              // error with lookup
+              if(this.normalisedEvents[idx].errors == undefined){
+                this.normalisedEvents[idx].errors = [];
+              }
+              this.normalisedEvents[idx].errors.push(lookupError);
+            }else{
+              postcodeData = cache.postcodes[postcode];
+            }
+          }else{
+            console.log(`Geopipe getting [${postcode}] from cache`);
+            postcodeData = cache.postcodes[postcode];
+          }
+
+          if(postcodeData != undefined){
+            this.addLocationData(this.normalisedEvents[idx], postcodeData);
+          }
+
+        }
+      }
+
+      resolve(this.normalisedEvents);
+    });
+  }
+
+  getPostcode(location){
+    if(location != undefined && 'address' in location){
+      if ('postalCode' in location.address){
+        return location.address.postalCode;
+      }
+    }
+  }
+
+  async lookupPostcode(postcode){
+    /*
+    Gets more geo data from postcode lookup service and
+    saves it in the postcode cache.
+    Returns undefined on success or error object on failure.
+    */
+    console.log(`Geopipe looking up [${postcode}]`);
+
+    try {
+      let url = 'https://postcodes.io/postcodes/' + postcode;
+      const res = await fetch(url);
+      const postcodeResult = await res.json();
+
+      if (postcodeResult.status == 200) {
+
+        console.log(`Geopipe found [${postcode}]`);
+
+        cache.postcodes[postcode] = {
+          "coordinates": [postcodeResult.result.longitude,postcodeResult.result.latitude],
+          "locality": postcodeResult.result.admin_district,
+          "region": postcodeResult.result.region,
+          "country": postcodeResult.result.country
+        };
+
+        return;
+
+      }else{
+        return { postcodeLookupFailed: `Geopipe could not look up postcode [${postcode}]\nStatus code: ${postcodeResult.status}\nResponse:\n${postcodeResult}`}
+      }
+
+    } catch (e) {
+      console.log(e);
+      return { missingPostcode: `Geopipe could not get postcode [${postcode}] Error: \n ${e}` };
+    }
+  }
+
+  addLocationData(normalisedEvent, postcodeData){
+
+    // Add data to `address` field if not set
+    if(!normalisedEvent.data.location.address.addressLocality){
+      normalisedEvent.data.location.address.addressLocality = postcodeData.locality
+    }
+    if(!normalisedEvent.data.location.address.addressRegion){
+      normalisedEvent.data.location.address.addressRegion = postcodeData.region
+    }
+  if(!normalisedEvent.data.location.address.addressCountry){
+      normalisedEvent.data.location.address.addressCountry = postcodeData.country
+    }
+    // Add data to `geo` field if not set
+    if(!normalisedEvent.data.location.geo){
+      normalisedEvent.data.location.geo = {
+        "@type": "GeoCoordinates",
+        "longitude": postcodeData.coordinates[0],
+        "latitude": postcodeData.coordinates[1]
+      }
+    }
+
+  }
+}
+
+export default GeoPipe;

--- a/src/lib/pipes/index.js
+++ b/src/lib/pipes/index.js
@@ -2,11 +2,15 @@
 import NormaliseEventPipe from './normalise-event-pipe.js';
 import NormaliseSlotPipe from './normalise-slot-pipe.js';
 import NormaliseSchedulePipe from './normalise-schedule-pipe.js';
+import GeoPipe from './geo-pipe.js';
 
 export default [
-  // Comment this out to see some test normalised events in the system
-  //TestPipe
+  // Test pipe - uncomment for test events
+  //TestPipe,
+  // Normalisation pipes - don't turn these off except for testing
   NormaliseEventPipe,
   NormaliseSlotPipe,
-  NormaliseSchedulePipe
+  NormaliseSchedulePipe,
+  // Data enhancement pipes - turn these on and off as needed
+  GeoPipe
 ];

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -66,7 +66,10 @@ class Utils {
 
 }
 
+var cache = { postcodes: {} };
+
 export {
+  cache,
   Utils,
 };
 

--- a/test/test-pipe-geo.js
+++ b/test/test-pipe-geo.js
@@ -1,0 +1,235 @@
+import assert from 'assert';
+import { cache } from '../src/lib/utils.js';
+import GeoPipe from '../src/lib/pipes/geo-pipe.js';
+import NormalisedEvent from '../src/lib/normalised-event.js';
+
+
+
+describe('geo-enhancement', function() {
+    it('should leave the data unchanged if no location', async function() {
+        const data = {"id": "event1", "kind": "Event",
+            "data": {
+            "@context": ["https://openactive.io/"],
+            "@id": "https://example.org/event",
+            "@type": "Event",
+            "name": "An event",
+            "startDate": "2020-06-02T15:32:00Z"
+        }};
+        const norm = new NormalisedEvent(data.data, "Event");
+        let pipe = new GeoPipe(data, [norm]);
+        let result = await pipe.run();
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0].data,data.data);
+    });
+
+    it('should leave the data unchanged if no postcode', async function() {
+        const data = {"id": "event1", "kind": "Event",
+            "data": {
+            "@context": ["https://openactive.io/"],
+            "@id": "https://example.org/event",
+            "@type": "Event",
+            "name": "An event",
+            "startDate": "2020-06-02T15:32:00Z",
+            "location": {
+                "@id": "https://goteamup.com/api/openactive/v1/id/place/10739",
+                "geo": {
+                  "@type": "GeoCoordinates",
+                  "latitude": 53.1654998,
+                  "longitude": -2.2045996
+                }
+            }
+        }};
+        const norm = new NormalisedEvent(data.data, "Event");
+        let pipe = new GeoPipe(data, [norm]);
+        let result = await pipe.run();
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0].data,data.data);
+    });
+
+    it('should get geo data from cache the second time', async function() {
+        const inputLoc = {
+          "location": {
+            "@type": "Place",
+            "url": "http://www.better.org.uk/leisure-centre/banes/bath-sports-and-leisure-centre",
+            "name": "Bath Sports and Leisure Centre",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "North Parade Road",
+                "postalCode": "BA2 4ET"
+            }
+          }
+        };
+        const input1 = {
+            "id": "event1", "kind": "Event",
+            "data": {
+              "@context": ["https://openactive.io/"],
+              "@type": "Event",
+              "name": "Event 1",
+              ...inputLoc
+            }
+        };
+        const input2 = {
+            "id": "event2", "kind": "Event",
+            "data": {
+              "@context": ["https://openactive.io/"],
+              "@type": "Event",
+              "name": "Event 2",
+              ...inputLoc
+            }
+        };
+
+        const outputLoc = {
+          "location": {
+            "@type": "Place",
+            "url": "http://www.better.org.uk/leisure-centre/banes/bath-sports-and-leisure-centre",
+            "name": "Bath Sports and Leisure Centre",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "North Parade Road",
+                "addressLocality": "Bath and North East Somerset",
+                "addressRegion": "South West",
+                "postalCode": "BA2 4ET",
+                "addressCountry": "England"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 51.381502,
+              "longitude": -2.35433
+            }
+          }
+        };
+        const output1 = {
+            "id": "event1", "kind": "Event",
+            "data": {
+              "@context": ["https://openactive.io/"],
+              "@type": "Event",
+              "name": "Event 1",
+              ...outputLoc
+            }
+        };
+        const output2 = {
+            "id": "event2", "kind": "Event",
+            "data": {
+              "@context": ["https://openactive.io/"],
+              "@type": "Event",
+              "name": "Event 2",
+              ...outputLoc
+            }
+        };
+
+        const norm1 = new NormalisedEvent(input1.data, "Event");
+        const norm2 = new NormalisedEvent(input2.data, "Event");
+        assert.equal(typeof cache.postcodes["BA2 4ET"], "undefined");
+        let pipe1 = new GeoPipe(input1, [norm1]);
+        let result1 = await pipe1.run();
+        assert.equal(typeof cache.postcodes["BA2 4ET"], "object");
+        let pipe2 = new GeoPipe(input2, [norm2]);
+        let result2 = await pipe2.run();
+
+    });
+
+    it('should add geo location info for a postcode', async function() {
+        const input = {"id": "event1", "kind": "Event",
+        "data": {
+          "@context": ["https://openactive.io/"],
+          "@type": "Event",
+          "location": {
+            "@type": "Place",
+            "url": "http://www.better.org.uk/leisure-centre/banes/bath-sports-and-leisure-centre",
+            "name": "Bath Sports and Leisure Centre",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "North Parade Road",
+                "addressLocality": "Bath",
+                "addressRegion": "Somerset",
+                "postalCode": "BA2 4ET",
+                "addressCountry": "GB"
+            }
+          }
+        }};
+
+        const output = {"id": "event1", "kind": "Event",
+        "data": {
+          "@context": ["https://openactive.io/"],
+          "@type": "Event",
+          "location": {
+            "@type": "Place",
+            "url": "http://www.better.org.uk/leisure-centre/banes/bath-sports-and-leisure-centre",
+            "name": "Bath Sports and Leisure Centre",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "North Parade Road",
+                "addressLocality": "Bath",
+                "addressRegion": "Somerset",
+                "postalCode": "BA2 4ET",
+                "addressCountry": "GB"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 51.381502,
+              "longitude": -2.35433
+            }
+          }
+        }};
+
+        const norm = new NormalisedEvent(input.data, "Event");
+        let pipe = new GeoPipe(input, [norm]);
+        let result = await pipe.run();
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0].data,output.data);
+    });
+
+    it('should add address info for a postcode', async function() {
+        const input = {"id": "event1", "kind": "Event",
+        "data": {
+          "@context": ["https://openactive.io/"],
+          "@type": "Event",
+          "location": {
+            "@type": "Place",
+            "url": "http://www.better.org.uk/leisure-centre/banes/bath-sports-and-leisure-centre",
+            "name": "Bath Sports and Leisure Centre",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "North Parade Road",
+                "postalCode": "BA2 4ET"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 51.381502,
+              "longitude": -2.35433
+            }
+          }
+        }};
+
+        const output = {"id": "event1", "kind": "Event",
+        "data": {
+          "@context": ["https://openactive.io/"],
+          "@type": "Event",
+          "location": {
+            "@type": "Place",
+            "url": "http://www.better.org.uk/leisure-centre/banes/bath-sports-and-leisure-centre",
+            "name": "Bath Sports and Leisure Centre",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "North Parade Road",
+                "addressLocality": "Bath and North East Somerset",
+                "addressRegion": "South West",
+                "postalCode": "BA2 4ET",
+                "addressCountry": "England"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 51.381502,
+              "longitude": -2.35433
+            }
+          }
+        }};
+
+        const norm = new NormalisedEvent(input.data, "Event");
+        let pipe = new GeoPipe(input, [norm]);
+        let result = await pipe.run();
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0].data,output.data);
+    });
+
+});


### PR DESCRIPTION
Adds address and geo information for objects with a postcode, operating on things already in normalisedData. Leaves anything without a postcode unchanged.

Refactored a bit from last time for readability and error handling.

A few changes because it needs to generate an OA spec conformant location now which is a bit different from what we did in the harvester last time.