### PR TITLE
docs: heroku-for-production: Remove "recommended"

### DIFF
--- a/docs/running-the-services/heroku-for-production.md
+++ b/docs/running-the-services/heroku-for-production.md
@@ -1,18 +1,16 @@
-# Live Hosting on Heroku \(recommended\)
+# Live Hosting on Heroku
 
 ## Initial Setup
 
 Create a new app in the "Europe" region.
 
-Add the "Heroku Postgres" addition. The free level only has 10,000 rows - we recommend you use a paid level as the database can grow quickly. 
+Add the "Heroku Postgres" addition. The free level only has 10,000 rows - we recommend you use a paid level as the database can grow quickly.
 
 Make sure the database is set as "Attach as DATABASE". If you go to "Settings" and "Reveal Config Vars" you should see details for it as "DATABASE\_URL".
 
 Do a deploy. You must do this by setting up the heroku CLI tool and a "git push" operation. \(This is because we use submodules, and that only works with a push: [https://devcenter.heroku.com/articles/git-submodules\#git-submodules](https://devcenter.heroku.com/articles/git-submodules#git-submodules) \)
 
-Select More, Run Command and put in "node ./src/bin/migrate-database.js". Wait for this to finish.
-
-Select More, and "Restart all dynos". \(This is so the code starts again with the correct database structure\)
+From the App dashboard select "More", "Run Console" and run the command `node ./src/bin/migrate-database.js`. After this has completed, Select "More", and "Restart all dynos". \(This is so the code starts again with the correct database structure\)
 
 Go to Resources - the "worker" Dyno should be enabled.
 


### PR DESCRIPTION
We leave it neutral as to what service this is deployed on. It should
work in a large number of setups for production.
Remove trailing blank space.