### PR TITLE
datatabase: add setting for SSL config

### DIFF
--- a/docs/running-the-services/heroku-for-production.md
+++ b/docs/running-the-services/heroku-for-production.md
@@ -4,9 +4,11 @@
 
 Create a new app in the "Europe" region.
 
-Add the "Heroku Postgres" addition. The free level only has 10,000 rows - we recommend you use a paid level as the database can grow quickly. 
+Add the "Heroku Postgres" addition. The free level only has 10,000 rows - we recommend you use a paid level as the database can grow quickly.
 
 Make sure the database is set as "Attach as DATABASE". If you go to "Settings" and "Reveal Config Vars" you should see details for it as "DATABASE\_URL".
+
+If using production (>= standard-0) postgres addon plan you must also add and set the Config var `DATABASE_USE_SSL` to "true".
 
 Do a deploy. You must do this by setting up the heroku CLI tool and a "git push" operation. \(This is because we use submodules, and that only works with a push: [https://devcenter.heroku.com/articles/git-submodules\#git-submodules](https://devcenter.heroku.com/articles/git-submodules#git-submodules) \)
 

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -5,6 +5,7 @@ import Settings from './settings.js';
 
 const database_pool = new pg.Pool({
       connectionString: Settings.postgresURL,
+      ssl: Settings.postgresSSL,
 });
 
 async function migrate_database() {

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -4,6 +4,7 @@ const Settings = {
   "spiderDataCatalogStartURL": process.env.SPIDER_DATA_CATALOG_START_URL || 'https://www.openactive.io/data-catalogs/data-catalog-collection.jsonld',
 
   "postgresURL": process.env.DATABASE_URL || 'postgres://app:app@localhost:5432/app',
+  "postgresSSL": process.env.DATABASE_USE_SSL ? true : false,
 
   // "PORT" as a env var name seems to match what Heroku wants: https://github.com/heroku/node-js-getting-started/blob/master/index.js#L3
   "webServerPort": process.env.PORT || 8000,


### PR DESCRIPTION
Heroku production requires SSL connections and doesn't allow this to be
set on the attachment url in the env var.