### PR TITLE
Activities augmentation pipe

### DIFF
--- a/docs/understanding-the-services/stage/normalise-data/enhancement-pipes.md
+++ b/docs/understanding-the-services/stage/normalise-data/enhancement-pipes.md
@@ -1,0 +1,27 @@
+# Enhancement pipes
+
+There are pipes which are run after the normalisation pipes to further improve the data. These may derive new data, that was not in the original source.
+
+## Geo
+
+For objects with a `location/address/postalCode` value, this pipe looks up the postcode on postcodes.io and, where not already present, adds:
+
+* `location/address/addressCountry`
+* `location/address/addressRegion`
+* `location/address/addressLocality`
+* `location/geo/longitude`
+* `location/geo/latitutde`
+
+## Activities
+
+This pipes expands the value of the `activities` list using the official [OA Activity List](https://www.openactive.io/activity-list/activity-list.jsonld).
+
+The OA Activity List is fetched once, indexed in a useful way, and cached. The URL for the list can be configured in `src/lib/settings.js`.
+
+It leaves any activity with its own `inScheme` alone, but otherwise:
+
+* If there are activities with no `id`/`@id`, but they have a label which is present in the Activity List, it fills in their ids
+* It gets the `broader` activities for anything in the Activity List and adds them
+* It searches the `name` and `description` of the event for labels from the Activity List and adds new activities if found
+
+Any activity values that are either explicitly from another Activity List, or simply aren't present in the OA Activity List are retained (but made into valid objects with `@type: Concept` if not already).

--- a/docs/understanding-the-services/stage/normalise-data/pipeline-overview.md
+++ b/docs/understanding-the-services/stage/normalise-data/pipeline-overview.md
@@ -25,4 +25,4 @@ There are three kinds of pipes:
 
 * [Normalisation pipes](normalisation-pipes.md)
 * Cleaning pipes
-* Enhancement pipes
+* [Enhancement pipes](enhancement-pipes.md)

--- a/src/lib/pipes/activities-pipe.js
+++ b/src/lib/pipes/activities-pipe.js
@@ -1,0 +1,108 @@
+import Pipe from './pipe.js';
+import { cache, Utils } from '../utils.js';
+import NormalisedEvent from '../normalised-event.js';
+
+/**
+Adds more activities to NormalisedEvents based on the
+hierarchy of activities in the OA Activity List as well
+as string matching in names and descriptions.
+**/
+class ActivitiesPipe extends Pipe {
+  run(){
+    return new Promise(async resolve => {
+
+      await this.updateActivitiesCache();
+
+      // Loop through the normalisedEvents
+      for(let idx in this.normalisedEvents) {
+
+      }
+
+      resolve(this.normalisedEvents);
+    });
+  }
+
+  async updateActivitiesCache(){
+    // Load the Activity List if not already cached
+    if(Object.keys(cache.activities).length == 0){
+      try{
+        await Utils.loadActivitiesJSONIntoCache();
+      }catch(e){
+        console.log(`ActivitiesPipe couldn't update cache\n${e}`);
+      }
+    }
+  }
+
+  /**
+  Most activities in the ActivityList only have a prefLabel but some have
+  altLabel so we should get this too.
+  **/
+  getActivityLabels(activityKey){
+    let labels = [];
+    let activityList = cache.activities;
+      // Get the labels from the cached ActivityList
+      labels.push(activityList[activityKey]['prefLabel']);
+      if (activityList[activityKey]['altLabel'] !== undefined){
+        activityList[activityKey]['altLabel'].forEach(function(altLabel){
+          labels.push(altLabel);
+        });
+      }
+    return labels;
+  }
+
+  /**
+  Recursively checks activities in the ActivityList for broader field
+  and returns all labels of broader concepts. The broader field is an
+  array of ids that can also be found in the ActivityList.
+  **/
+  getBroaderActivities(activityKeys, activitiesSoFar = []){
+    let activityList = cache.activities;
+
+    if (!Array.isArray(activityKeys)){
+      activityKeys = [activityKeys];
+    }
+
+    for (let activityKey of activityKeys){
+
+      let broaderKeys = activityList[activityKey]['broader'];
+      if (broaderKeys !== undefined){
+        let broaderLabels = [];
+        for (let broaderKey of broaderKeys){
+          let broaderLabel = this.getActivityLabels(this.normaliseActivityId(broaderKey));
+          broaderLabels = broaderLabels.concat(broaderLabel);
+          console.log(`ActivitiesPipe found broader activity: [${broaderLabel}]`);
+        }
+        activitiesSoFar = activitiesSoFar.concat(broaderLabels);
+        return this.getBroaderActivities(broaderKeys, activitiesSoFar);
+      }
+
+    }
+
+    return activitiesSoFar;
+  }
+
+  /**
+  Simple string in string matching, only matches complete words,
+  which helps to avoid false positives from substrings.
+  **/
+  searchTextForActivity(text, activity){
+    const regex = new RegExp("\\b"+activity+"\\b");
+    let result = text.search(regex) !== -1;
+    // if (result){
+    //   this.log(`Found [${activity}] in "${text}"`);
+    // }
+    return result;
+  }
+
+  /**
+  In the ActivityList ids take the form https://openactive.io/activity-list#{id}
+  but some data uses http, www, and/or a forward slash before the #{id}. So let's strip these out.
+  **/
+  normaliseActivityId(activityId){
+    let normed = activityId.replace("http://", "https://").replace("www.", "").replace("/#", "#");
+    return normed;
+  }
+}
+
+
+export default ActivitiesPipe;

--- a/src/lib/pipes/activities-pipe.js
+++ b/src/lib/pipes/activities-pipe.js
@@ -11,6 +11,8 @@ class ActivitiesPipe extends Pipe {
   run(){
     return new Promise(async resolve => {
 
+      console.log(`Running ${this.normalisedEvents.length} normalised events through ${this.constructor.name}`);
+
       await this.updateActivitiesCache();
 
       // Loop through the normalisedEvents
@@ -23,8 +25,9 @@ class ActivitiesPipe extends Pipe {
         // and add them back later
         let unchangedActivities = [];
 
-        // For each value in `activity`
         if(Array.isArray(this.normalisedEvents[idx].data.activity)){
+
+          // For each value in `activity`
           for(let activity of this.normalisedEvents[idx].data.activity){
 
             if(activity != undefined){
@@ -67,15 +70,18 @@ class ActivitiesPipe extends Pipe {
         }
 
         // Add any new activities back to the normalised event
-        this.normalisedEvents[idx].data.activity = unchangedActivities;
-        for(let id of activityIds){
-          let outputActivity = {
-            "@id": id,
-            "@type": "Concept",
-            "prefLabel": cache.activities.byId[id].prefLabel,
-            "inScheme": "https://openactive.io/activity-list"
+        if(unchangedActivities.length > 0 || activityIds.length > 0){
+          this.normalisedEvents[idx].data.activity = unchangedActivities;
+
+          for(let id of activityIds){
+            let outputActivity = {
+              "@id": id,
+              "@type": "Concept",
+              "prefLabel": cache.activities.byId[id].prefLabel,
+              "inScheme": "https://openactive.io/activity-list"
+            }
+            this.normalisedEvents[idx].data.activity.push(outputActivity);
           }
-          this.normalisedEvents[idx].data.activity.push(outputActivity);
         }
       }
 

--- a/src/lib/pipes/activities-pipe.js
+++ b/src/lib/pipes/activities-pipe.js
@@ -70,7 +70,7 @@ class ActivitiesPipe extends Pipe {
         }
 
         // Add any new activities back to the normalised event
-        if(unchangedActivities.length > 0 || activityIds.length > 0){
+        if(unchangedActivities.length > 0 || activityIds.size > 0){
           this.normalisedEvents[idx].data.activity = unchangedActivities;
 
           for(let id of activityIds){

--- a/src/lib/pipes/index.js
+++ b/src/lib/pipes/index.js
@@ -3,6 +3,7 @@ import NormaliseEventPipe from './normalise-event-pipe.js';
 import NormaliseSlotPipe from './normalise-slot-pipe.js';
 import NormaliseSchedulePipe from './normalise-schedule-pipe.js';
 import GeoPipe from './geo-pipe.js';
+import ActivitiesPipe from './activities-pipe.js';
 
 export default [
   // Test pipe - uncomment for test events
@@ -12,5 +13,6 @@ export default [
   NormaliseSlotPipe,
   NormaliseSchedulePipe,
   // Data enhancement pipes - turn these on and off as needed
-  GeoPipe
+  GeoPipe,
+  ActivitiesPipe
 ];

--- a/src/lib/pipes/pipe.js
+++ b/src/lib/pipes/pipe.js
@@ -188,10 +188,20 @@ class Pipe {
   }
 
   expandActivity(activity){
-    if(activity !== 'undefined' && typeof activity === 'string'){
-      activity = {
-        "@type": "Concept",
-        "prefLabel": activity
+    if(activity !== 'undefined'){
+      if(typeof activity === 'string'){
+        activity = {
+          "@type": "Concept",
+          "prefLabel": activity
+        }
+      }else if(typeof activity === 'object' && !Array.isArray(activity)){
+        if(activity.type != undefined){
+          activity["@type"] = activity.type;
+          delete activity.type;
+        }
+        if(activity["@type"] == undefined){
+          activity["@type"] = "Concept";
+        }
       }
     }
     return activity;

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -31,6 +31,9 @@ const Settings = {
   "contextJsonld": "https://www.openactive.io/ns/oa.jsonld",
   "betaContextJsonld": "https://www.openactive.io/ns-beta/oa.jsonld",
 
+  // Activity List
+  "activityListJSONLD": "https://www.openactive.io/activity-list/activity-list.jsonld",
+
   // TLS Setting
   // Some publishers may only support older versions
   "tlsDefaultMinimumVersion": "TLSv1",

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -72,10 +72,20 @@ class Utils {
     // TODO handle errors / non 200 responses
     const activitiesData =  await res.json();
 
-    cache.activities = {};
+    cache.activities = {"byId": {}, "byLabel": {}};
 
     for(let idx in activitiesData.concept) {
-      cache.activities[activitiesData.concept[idx].id] = activitiesData.concept[idx];
+      // Index by id
+      cache.activities.byId[activitiesData.concept[idx].id] = activitiesData.concept[idx];
+      // Index by prefLabel
+      cache.activities.byLabel[activitiesData.concept[idx].prefLabel] = activitiesData.concept[idx];
+      // Index by altLabel
+      let altLabels = activitiesData.concept[idx].altLabel;
+      if(altLabels != undefined && altLabels.length > 0){
+        for (let altLabel of altLabels){
+          cache.activities.byLabel[altLabel] = activitiesData.concept[idx];
+        }
+      }
     }
 
   }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,5 +1,7 @@
 import { promises as fs } from 'fs';
+import fetch from 'node-fetch';
 import path from 'path';
+import Settings from './settings.js';
 
 
 class Utils {
@@ -64,9 +66,23 @@ class Utils {
     }
   }
 
+  static async loadActivitiesJSONIntoCache() {
+
+    const res = await fetch(Settings.activityListJSONLD);
+    // TODO handle errors / non 200 responses
+    const activitiesData =  await res.json();
+
+    cache.activities = {};
+
+    for(let idx in activitiesData.concept) {
+      cache.activities[activitiesData.concept[idx].id] = activitiesData.concept[idx];
+    }
+
+  }
+
 }
 
-var cache = { postcodes: {} };
+var cache = { postcodes: {}, activities: {} };
 
 export {
   cache,

--- a/test/test-pipe-activities.js
+++ b/test/test-pipe-activities.js
@@ -1,0 +1,171 @@
+import assert from 'assert';
+import { cache } from '../src/lib/utils.js';
+import ActivitiesPipe from '../src/lib/pipes/activities-pipe.js';
+import NormalisedEvent from '../src/lib/normalised-event.js';
+
+
+
+describe('activity-string-matching', function() {
+
+    it('finds the word yoga in a longer string', async function() {
+      const description = "These beginner yoga classes are fun for all the family";
+      const pipe = new ActivitiesPipe({},[]);
+      let result = await pipe.searchTextForActivity(description, "yoga");
+      assert.equal(result,true);
+    });
+
+    it('does not find the word yoga in a longer string', async function() {
+      const description = "These beginner tennis classes are fun for all the family";
+      const pipe = new ActivitiesPipe({},[]);
+      let result = await pipe.searchTextForActivity(description, "yoga");
+      assert.equal(result,false);
+    });
+
+    it('does not find the word gin when it is a substring', async function() {
+      const description = "These beginner yoga classes are fun for all the family";
+      const pipe = new ActivitiesPipe({},[]);
+      let result = await pipe.searchTextForActivity(description, "gin");
+      assert.equal(result,false);
+    });
+
+});
+
+describe('activity-id-fixing', function(){
+
+  it('leaves a valid activity id unchanged', function(){
+    const uri = "https://openactive.io/activity-list#1a2b3c4d";
+    const pipe = new ActivitiesPipe({},[]);
+    let result = pipe.normaliseActivityId(uri);
+    assert.equal(result,uri);
+  });
+
+  it('fixes http URIs', function(){
+    const uri = "https://openactive.io/activity-list#1a2b3c4d";
+    const pipe = new ActivitiesPipe({},[]);
+    let result = pipe.normaliseActivityId("http://openactive.io/activity-list#1a2b3c4d");
+    assert.equal(result,uri);
+  });
+
+  it('fixes URIs with www', function(){
+    const uri = "https://openactive.io/activity-list#1a2b3c4d";
+    const pipe = new ActivitiesPipe({},[]);
+    let result = pipe.normaliseActivityId("https://www.openactive.io/activity-list#1a2b3c4d");
+    assert.equal(result,uri);
+  });
+
+  it('fixes URIs with extra forward slash', function(){
+    const uri = "https://openactive.io/activity-list#1a2b3c4d";
+    const pipe = new ActivitiesPipe({},[]);
+    let result = pipe.normaliseActivityId("https://openactive.io/activity-list/#1a2b3c4d");
+    assert.equal(result,uri);
+  });
+
+  it('fixes URIs with http, www and extra forward slash', function(){
+    const uri = "https://openactive.io/activity-list#1a2b3c4d";
+    const pipe = new ActivitiesPipe({},[]);
+    let result = pipe.normaliseActivityId("http://www.openactive.io/activity-list/#1a2b3c4d");
+    assert.equal(result,uri);
+  });
+
+});
+
+describe('getting-activity-labels', function(){
+
+  it('gets pref labels', function(){
+    cache.activities = {
+      "https://openactive.io/activity-list#7f4": {
+        id: "https://openactive.io/activity-list#7f4",
+        identifier: "7f4",
+        type: "Concept",
+        prefLabel: "Haggis chasing",
+        broader: [
+          "https://openactive.io/activity-list#78503fa2-ed24-4a80-a224-e2e94581d8a8"
+        ],
+        definition: "A traditional Scottish coming-of-age ritual",
+        notation: "haggis_chasing"
+      },
+      "https://openactive.io/activity-list#8d3": {
+        id: "https://openactive.io/activity-list#8d3",
+        identifier: "7f4",
+        type: "Concept",
+        prefLabel: "Caber tossing",
+        definition: "An event that takes place during the Highland Games",
+        notation: "caber_tossing"
+      }
+    };
+
+    const pipe = new ActivitiesPipe({},[]);
+    let result = pipe.getActivityLabels("https://openactive.io/activity-list#7f4");
+    assert.equal(result.length,1);
+    assert.equal(result[0], "Haggis chasing");
+  });
+
+  it('gets alt labels', function(){
+    cache.activities = {
+      "https://openactive.io/activity-list#7f4": {
+        id: "https://openactive.io/activity-list#7f4",
+        identifier: "7f4",
+        type: "Concept",
+        prefLabel: "Haggis chasing",
+        altLabel: ["Chasing yer taigeis"],
+        broader: [
+          "https://openactive.io/activity-list#78503fa2-ed24-4a80-a224-e2e94581d8a8"
+        ],
+        definition: "A traditional Scottish coming-of-age ritual",
+        notation: "haggis_chasing"
+      }
+    };
+    const pipe = new ActivitiesPipe({},[]);
+    let result = pipe.getActivityLabels("https://openactive.io/activity-list#7f4");
+    assert.equal(result.length,2);
+    assert.equal(result[0], "Haggis chasing");
+    assert.equal(result[1], "Chasing yer taigeis");
+  });
+
+});
+
+describe('getting-broader-activities', function(){
+  it('should get labels for activities broader in the heirarcy', function(){
+    cache.activities = {
+      "https://openactive.io/activity-list#f816f3b5-3128-4421-b71a-25cc7c1e1880": {
+        "identifier": "f816f3b5-3128-4421-b71a-25cc7c1e1880",
+        "type": "Concept",
+        "prefLabel": "6-a-side",
+        "broader": [
+          "https://openactive.io/activity-list#22fe3033-b0e4-4717-8455-599180b5bcba"
+        ],
+        "notation": "6_a_side"
+      },
+      "https://openactive.io/activity-list#22fe3033-b0e4-4717-8455-599180b5bcba": {
+        "identifier": "22fe3033-b0e4-4717-8455-599180b5bcba",
+        "type": "Concept",
+        "prefLabel": "Small Sided Football",
+        "broader": [
+          "https://openactive.io/activity-list#0a5f732d-e806-4e51-ad40-0a7de0239c8c"
+        ],
+        "notation": "small_sided_football"
+      },
+      "https://openactive.io/activity-list#0a5f732d-e806-4e51-ad40-0a7de0239c8c": {
+        "identifier": "0a5f732d-e806-4e51-ad40-0a7de0239c8c",
+        "type": "Concept",
+        "prefLabel": "Football",
+        "definition": "Football is widely considered to be the most popular sport in the world. The beautiful game is England's national sport.",
+        "notation": "football",
+        "topConceptOf": "https://openactive.io/activity-list"
+      },
+      "https://openactive.io/activity-list#4ba72fbb-fc08-4f3e-b779-342be690bc1c": {
+        "identifier": "4ba72fbb-fc08-4f3e-b779-342be690bc1c",
+        "type": "Concept",
+        "prefLabel": "Footgolf",
+        "definition": "Footgolf is played on a golf course using a size 5 football.",
+        "notation": "footgolf",
+        "topConceptOf": "https://openactive.io/activity-list"
+      }
+    };
+    const pipe = new ActivitiesPipe({},[]);
+    let result = pipe.getBroaderActivities("https://openactive.io/activity-list#f816f3b5-3128-4421-b71a-25cc7c1e1880");
+    assert.equal(result.length,2);
+    assert.equal(result[0], "Small Sided Football");
+    assert.equal(result[1], "Football");
+  });
+});

--- a/test/test-pipe-activities.js
+++ b/test/test-pipe-activities.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
-import { cache } from '../src/lib/utils.js';
+import path from 'path';
+import { cache, Utils } from '../src/lib/utils.js';
 import ActivitiesPipe from '../src/lib/pipes/activities-pipe.js';
 import NormalisedEvent from '../src/lib/normalised-event.js';
 
@@ -72,7 +73,7 @@ describe('activity-id-fixing', function(){
 describe('getting-activity-labels', function(){
 
   it('gets pref labels', function(){
-    cache.activities = {
+    cache.activities.byId = {
       "https://openactive.io/activity-list#7f4": {
         id: "https://openactive.io/activity-list#7f4",
         identifier: "7f4",
@@ -101,7 +102,7 @@ describe('getting-activity-labels', function(){
   });
 
   it('gets alt labels', function(){
-    cache.activities = {
+    cache.activities.byId = {
       "https://openactive.io/activity-list#7f4": {
         id: "https://openactive.io/activity-list#7f4",
         identifier: "7f4",
@@ -125,8 +126,8 @@ describe('getting-activity-labels', function(){
 });
 
 describe('getting-broader-activities', function(){
-  it('should get labels for activities broader in the heirarcy', function(){
-    cache.activities = {
+  it('should get labels for activities broader in the hierarchy', function(){
+    cache.activities.byId = {
       "https://openactive.io/activity-list#f816f3b5-3128-4421-b71a-25cc7c1e1880": {
         "identifier": "f816f3b5-3128-4421-b71a-25cc7c1e1880",
         "type": "Concept",
@@ -165,7 +166,267 @@ describe('getting-broader-activities', function(){
     const pipe = new ActivitiesPipe({},[]);
     let result = pipe.getBroaderActivities("https://openactive.io/activity-list#f816f3b5-3128-4421-b71a-25cc7c1e1880");
     assert.equal(result.length,2);
-    assert.equal(result[0], "Small Sided Football");
-    assert.equal(result[1], "Football");
+    assert.equal(result[0]["prefLabel"], "Small Sided Football");
+    assert.equal(result[1]["prefLabel"], "Football");
   });
+});
+
+describe('augment-activities', function(){
+
+  // Each of these resets the activities cache so it's fetched again
+  // as previous tests modified it
+  // Very occasionally the get request might take too long and a test
+  // times out.. just run them again..
+
+  it('should not drop any non-OA activities', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    const inputActivity = [
+      {
+        "@id": "https://example.org/activity/running",
+        "@type": "Concept",
+        "inScheme": "https://example.org/activitylist"
+      }
+    ];
+    input.data.description = "asdf!";
+    input.data.activity = [...inputActivity];
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, inputActivity);
+  });
+
+  it('should not drop activity with id not in OA list', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    const inputActivity = [
+      {
+        "@id": "https://example.org/activity/running",
+        "@type": "Concept",
+        "prefLabel": "Running"
+      }
+    ];
+    input.data.description = "asdf!";
+    input.data.activity = [...inputActivity];
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, inputActivity);
+  });
+
+  it('should not drop activity with label not in OA list', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    const inputActivity = [
+      {
+        "@type": "Concept",
+        "prefLabel": "asdfasdf"
+      }
+    ];
+    input.data.description = "asdf!";
+    input.data.activity = [...inputActivity];
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, inputActivity);
+  });
+
+  it('should add labels when only id provided', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    const inputActivity = [
+      {
+        "@id": "https://openactive.io/activity-list#72ddb2dc-7d75-424e-880a-d90eabe91381"
+      }
+    ];
+    const outputActivity = [
+      {
+        "@id": "https://openactive.io/activity-list#72ddb2dc-7d75-424e-880a-d90eabe91381",
+        "@type": "Concept",
+        "prefLabel": "Running",
+        "inScheme": "https://openactive.io/activity-list"
+      }
+    ];
+    input.data.description = "asdf!";
+    input.data.activity = [...inputActivity];
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, outputActivity);
+  });
+
+  it('should add id when only label provided', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    const inputActivity = [
+      {
+        "@type": "Concept",
+        "prefLabel": "Running"
+      }
+    ];
+    const outputActivity = [
+      {
+        "@id": "https://openactive.io/activity-list#72ddb2dc-7d75-424e-880a-d90eabe91381",
+        "@type": "Concept",
+        "prefLabel": "Running",
+        "inScheme": "https://openactive.io/activity-list"
+      }
+    ];
+    input.data.description = "asdf!";
+    input.data.activity = [...inputActivity];
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, outputActivity);
+  });
+
+  it('should add id and set to OA prefLabel when only label provided and it is an altLabel', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    const inputActivity = [
+      {
+        "@type": "Concept",
+        "prefLabel": "Rambling"
+      }
+    ];
+    const outputActivity = [
+      {
+        "@id": "https://openactive.io/activity-list#95092977-5a20-4d6e-b312-8fddabe71544",
+        "@type": "Concept",
+        "prefLabel": "Walking",
+        "inScheme": "https://openactive.io/activity-list"
+      }
+    ];
+    input.data.description = "asdf!";
+    input.data.activity = [...inputActivity];
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, outputActivity);
+  });
+
+  it('should add broader activities', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    const inputActivity = [
+      {
+        "id": "https://openactive.io/activity-list#90346371-03e3-47c8-a25d-07e976b4a4c8",
+        "prefLabel": "Fell Running"
+      }
+    ];
+    const outputActivity = [
+      {
+        "@id": "https://openactive.io/activity-list#90346371-03e3-47c8-a25d-07e976b4a4c8",
+        "@type": "Concept",
+        "prefLabel": "Fell Running",
+        "inScheme": "https://openactive.io/activity-list"
+      },
+      {
+        "@id": "https://openactive.io/activity-list#72ddb2dc-7d75-424e-880a-d90eabe91381",
+        "@type": "Concept",
+        "prefLabel": "Running",
+        "inScheme": "https://openactive.io/activity-list"
+      }
+    ];
+    input.data.description = "asdf!";
+    input.data.activity = [...inputActivity];
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, outputActivity);
+  });
+
+  it('should extract more activities from description', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    const inputActivity = [
+      {
+        "@type": "Concept",
+        "prefLabel": "Jogging"
+      }
+    ];
+    const outputActivity = [
+      {
+        "@type": "Concept",
+        "prefLabel": "Jogging"
+      },
+      {
+        "@id": "https://openactive.io/activity-list#72ddb2dc-7d75-424e-880a-d90eabe91381",
+        "@type": "Concept",
+        "prefLabel": "Running",
+        "inScheme": "https://openactive.io/activity-list"
+      }
+    ];
+    input.data.activity = [...inputActivity];
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, outputActivity);
+  });
+
+  it('should get broader and extract activities from name', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    delete input.data.activity;
+    const outputActivity = [
+      {
+        "@id": "https://openactive.io/activity-list#90346371-03e3-47c8-a25d-07e976b4a4c8",
+        "@type": "Concept",
+        "prefLabel": "Fell Running",
+        "inScheme": "https://openactive.io/activity-list"
+      },
+      {
+        "@id": "https://openactive.io/activity-list#72ddb2dc-7d75-424e-880a-d90eabe91381",
+        "@type": "Concept",
+        "prefLabel": "Running",
+        "inScheme": "https://openactive.io/activity-list"
+      }
+    ];
+    input.data.name = "Fell running with Tom";
+    input.data.description = "asdf!";
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, outputActivity);
+  });
+
+  it('should get broader and keep non-OA activities', async function(){
+    cache.activities = {};
+    const input = await Utils.readJson(path.resolve(path.resolve(), './test/fixtures/event-normalised.json'));
+    const inputActivity = [
+      {
+        "@type": "Concept",
+        "prefLabel": "Jogging"
+      },
+      {
+        "id": "https://openactive.io/activity-list#90346371-03e3-47c8-a25d-07e976b4a4c8",
+        "prefLabel": "Fell Running"
+      }
+    ];
+    const outputActivity = [
+      {
+        "@type": "Concept",
+        "prefLabel": "Jogging"
+      },
+      {
+        "@id": "https://openactive.io/activity-list#90346371-03e3-47c8-a25d-07e976b4a4c8",
+        "@type": "Concept",
+        "prefLabel": "Fell Running",
+        "inScheme": "https://openactive.io/activity-list"
+      },
+      {
+        "@id": "https://openactive.io/activity-list#72ddb2dc-7d75-424e-880a-d90eabe91381",
+        "@type": "Concept",
+        "prefLabel": "Running",
+        "inScheme": "https://openactive.io/activity-list"
+      }
+    ];
+    input.data.description = "asdf!";
+    input.data.activity = [...inputActivity];
+    const normEvent = new NormalisedEvent(input.data, "Event");
+    const pipe = new ActivitiesPipe(input.data, [normEvent]);
+    let result = await pipe.run();
+    assert.deepEqual(result[0].data.activity, outputActivity);
+  });
+
 });

--- a/test/test-pipe.js
+++ b/test/test-pipe.js
@@ -358,6 +358,63 @@ describe('pipe-fix-types', function(){
     // });
 });
 
+describe('expand-activity', function(){
+    it('should make a string activity into proper objects', function(){
+        const input = {
+            "@type": "Event",
+            "activity": "Running"
+        };
+        const output = {
+            "@type": "Event",
+            "activity": [{
+                "@type": "Concept",
+                "prefLabel": "Running"
+            }]
+        };
+        let pipe = new NormaliseEventPipe({id: 1, data: input}, []);
+        pipe.expandObjects();
+        assert.deepEqual(pipe.rawData, output);
+    });
+
+    it('should make multiple string activities into proper objects', function(){
+        const input = {
+            "@type": "Event",
+            "activity": ["Running", "Jogging"]
+        };
+        const output = {
+            "@type": "Event",
+            "activity": [{
+                "@type": "Concept",
+                "prefLabel": "Running"
+            },
+            {
+                "@type": "Concept",
+                "prefLabel": "Jogging"
+            }]
+        };
+        let pipe = new NormaliseEventPipe({id: 1, data: input}, []);
+        pipe.expandObjects();
+        assert.deepEqual(pipe.rawData, output);
+    });
+
+    it('should make partial object activities into proper objects', function(){
+        const input = {
+            "@type": "Event",
+            "activity": [{"prefLabel": "Running"}]
+        };
+        const output = {
+            "@type": "Event",
+            "activity": [{
+                "@type": "Concept",
+                "prefLabel": "Running"
+            }]
+        };
+        let pipe = new NormaliseEventPipe({id: 1, data: input}, []);
+        pipe.expandObjects();
+        assert.deepEqual(pipe.rawData, output);
+    });
+});
+
 describe('pipe-rawdata-lookup', function(){
     it('should get one row from the raw_data table', async function(){
         const event = {

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import Utils from '../src/lib/utils.js';
+import {cache, Utils} from '../src/lib/utils.js';
 
 
 describe('makeNextURL', function() {
@@ -69,5 +69,17 @@ describe('getIdFromData', function(){
     it('should return undefined if data is null', function(){
         const id = Utils.getIdFromData(null);
         assert.deepEqual(id, undefined);
+    });
+});
+
+describe('activities-cache', function(){
+    it('should load the remote Activity List into the cache', async function(){
+        assert.equal(Object.keys(cache.activities).length, 0);
+        try{
+            await Utils.loadActivitiesJSONIntoCache();
+        }catch(e){
+            console.log(e);
+        }
+        assert.equal(Object.keys(cache.activities).length>0,true);
     });
 });

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -74,6 +74,7 @@ describe('getIdFromData', function(){
 
 describe('activities-cache', function(){
     it('should load the remote Activity List into the cache', async function(){
+        cache.activities = {};
         assert.equal(Object.keys(cache.activities).length, 0);
         try{
             await Utils.loadActivitiesJSONIntoCache();


### PR DESCRIPTION
This pipes expands the value of the `activities` list using the OA official Activity List.

It leaves anything with its own `inScheme` alone, but otherwise:

* If there are activities with no ids, but they have labels present in the Activity List, it fills in their ids
* It gets the `broader` activities for anything in the Activity List and adds them
* It searches the name and description of the event for labels from the Activity List and adds new activities if found
