### PR TITLE
dependencies: npm update and fix test that failed as a result.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,24 +5,25 @@
   "requires": true,
   "dependencies": {
     "@openactive/data-model-validator": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@openactive/data-model-validator/-/data-model-validator-2.0.25.tgz",
-      "integrity": "sha512-mZPMVJmKnmYGpqWOkPJt8j5byXOUIPBIG2WsuceS1qlI8MJQx2W6/RHNVgzcmKq/qzMKndeT81XSQUkjB3e3Wg==",
+      "version": "2.0.34",
+      "resolved": "https://registry.npmjs.org/@openactive/data-model-validator/-/data-model-validator-2.0.34.tgz",
+      "integrity": "sha512-gcNJRJ/JhLzCiYVXzQP4OMt6dpFyBI7wPQR1JZr0T4ZEngQoyRiYnJ6gXQdEoj+u3KlqKC1vnKBavycUyJFpSA==",
       "requires": {
-        "@openactive/data-models": "^2.0.64",
+        "@openactive/data-models": "^2.0.127",
         "axios": "^0.19.2",
         "currency-codes": "^1.5.1",
         "jsonpath": "^1.0.2",
         "moment": "^2.24.0",
         "rrule": "^2.6.2",
         "uritemplate": "^0.3.4",
-        "validator": "^10.11.0"
+        "validator": "^10.11.0",
+        "write-file-atomic": "^3.0.3"
       }
     },
     "@openactive/data-models": {
-      "version": "2.0.124",
-      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.124.tgz",
-      "integrity": "sha512-BMwUUI5cCHOLfW6Npiw9SSQJcSrsxEneu6SCCsEF3pBPbCbboZD9RzgZk8M5vxs4CADNEALdX+LUCQaD+bWQyA=="
+      "version": "2.0.127",
+      "resolved": "https://registry.npmjs.org/@openactive/data-models/-/data-models-2.0.127.tgz",
+      "integrity": "sha512-53yGYMMinW6ndON0nWbgImzT6NueF7ulLaupuokAb+JJlOxZNpbhkl9ZQAhorX8icfgiB5vBY6Evc8NSf2eN0Q=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -1179,8 +1180,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1320,8 +1320,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -2183,8 +2182,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -2358,7 +2356,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -2650,7 +2647,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
   },
   "homepage": "https://github.com/openactive/feed-normaliser#readme",
   "dependencies": {
-    "@openactive/data-model-validator": "^2.0.25",
+    "@openactive/data-model-validator": "^2.0.34",
     "ajv": "^6.12.3",
     "cheerio": "^1.0.0-rc.3",
     "express": "^4.17.1",
+    "iso8601-duration": "^1.2.0",
     "node-fetch": "^2.6.0",
     "object-hash": "^2.0.3",
     "pg": "^8.3.0",
     "postgres-migrations": "^4.0.3",
-    "rrule": "^2.6.4",
-    "iso8601-duration": "^1.2.0"
+    "rrule": "^2.6.4"
   },
   "devDependencies": {
     "mocha": "^7.1.2",

--- a/test/fixtures/event-normalised.json
+++ b/test/fixtures/event-normalised.json
@@ -26,6 +26,7 @@
     "url": "http://www.goodgym.org/happenings/hill-session-with-tom?utm_medium=openactive&utm_source=default",
     "description": "Come along for a challenging but rewarding interval session with Tom!\nAfter a warm up and running drills we'll be getting stuck into sets or short, fast hills that help develop speed and power, mixing these with race effort running. Come along, get fitter, simple!\nThe session is tough but reward to totally achievable FOR ALL ABILITIES!\nMeeting at Mile End Park, at the base of the Green Bridge at the southern end.\n",
     "beta:formattedDescription": "Come along for a challenging but rewarding interval session with Tom!\r\n\r\nAfter a warm up and running drills we'll be getting stuck into sets or short, fast hills that help develop speed and power, mixing these with race effort running. Come along, get fitter, simple!\r\n\r\nThe session is tough but reward to totally achievable FOR ALL ABILITIES!\r\n\r\nMeeting at Mile End Park, at the base of the Green Bridge at the southern end.",
+    "disambiguatingDescription": "A short, but tough session for speed and power",
     "activity": [{
       "@type": "Concept",
       "prefLabel": "Running"
@@ -75,8 +76,7 @@
         "name": "Another Park"
       },
       "location": { "areaServed": "London" },
-      "publicAccess": true,
-      "disambiguatingDescription": "A short, but tough session for speed and power"
+      "publicAccess": true
     }
   }
 }


### PR DESCRIPTION
An update to the OA data-model-validator means that upstream
schema.org fields are no longer flagged as field_not_in_spec, so
the fixtures have been updated to reflect that.