### PR TITLE
settings: Reduce all WorkLimits

### DIFF
--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -42,9 +42,9 @@ const Settings = {
 
   "dataProfiles": ["core", "accessibility", "socialrx"],
 
-  "normaliseDataLoadWorkLimit": 1000,
-  "profileNormalisedDataLoadWorkLimit": 1000,
-  "validateRawDataLoadWorkLimit": 1000
+  "normaliseDataLoadWorkLimit": 100,
+  "profileNormalisedDataLoadWorkLimit": 100,
+  "validateRawDataLoadWorkLimit": 100
 
 }
 


### PR DESCRIPTION
We only have a limited amount of memory and normaliseData can expand
greatly even from 100 raw data items.