### PR TITLE
lib: database: Only include 'deleted' state data in clean up

### DIFF
--- a/docs/running-the-services/maintaining-the-database.md
+++ b/docs/running-the-services/maintaining-the-database.md
@@ -6,7 +6,7 @@ Migrations for the database schema can be applied using `migrate-database.js`
 
 ## Deleting old data
 
-There is a utility called `clean-up-database.js` this will delete all data from the raw_data table that is older than the current value in environment variable `MAX_DATA_AGE_DAYS`, by default this is set to 14 days.
+There is a utility called `clean-up-database.js` this will delete all data from the raw_data table that has been deleted by the publisher and is older than the current value in environment variable `MAX_DATA_AGE_DAYS`, by default this is set to 14 days.
 
 The database is set up so that these deletes will cascade e.g. A normalised event item which is from a raw data item will be deleted if the raw data item is deleted.
 

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -48,7 +48,7 @@ async function clean_up_database() {
          */
         const date = new Date();
         date.setHours(-1* (date.getHours() + (Settings.maxDataAgeDays * 24)));
-        await client.query("DELETE FROM raw_data WHERE updated_at < $1", [date]);
+        await client.query("DELETE FROM raw_data WHERE updated_at < $1 AND data_deleted=TRUE", [date]);
     } finally {
         await client.end();
     }


### PR DESCRIPTION
For now only delete the raw data that has been marked as deleted by the
publisher (via their RPDE feed) that is older than 14 days. If everyone
is using RPDE correctly this should be enough to keep the database
"synchronised".